### PR TITLE
use gzip

### DIFF
--- a/spec/s3_meta_sync_spec.rb
+++ b/spec/s3_meta_sync_spec.rb
@@ -261,13 +261,13 @@ describe S3MetaSync do
     end
 
     it "retries once on ssl error" do
-      syncer.should_receive(:open).and_raise OpenSSL::SSL::SSLError.new
-      syncer.should_receive(:open).and_return stub(:read => "fff")
+      syncer.should_receive(:get).and_raise OpenSSL::SSL::SSLError.new
+      syncer.should_receive(:get).and_return "fff"
       syncer.send(:download_content, "bar/xxx").should == "fff"
     end
 
     it "does not retry multiple times on ssl error" do
-      syncer.should_receive(:open).exactly(2).and_raise OpenSSL::SSL::SSLError.new
+      syncer.should_receive(:get).exactly(2).and_raise OpenSSL::SSL::SSLError.new
       expect { syncer.send(:download_content, "bar/xxx") }.to raise_error(OpenSSL::SSL::SSLError)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 require "s3_meta_sync"
 require "tmpdir"
+require "open-uri"


### PR DESCRIPTION
according to docs ruby http should use gzip, using activity monitor I could only verify 6.9MB -> 6.2MB change which is much lower than we expected ... any better way to verify if this works ?

change line 66 + `[0..100]`
change line 113 to `puts "DONE"; sleep` to keep it running/in activity monitor

```
bundle exec ruby ./bin/s3-meta-sync zendesk_i18n-staging:translations testing
```

before:
![screen shot 2014-11-19 at 8 47 40 pm](https://cloud.githubusercontent.com/assets/11367/5119904/cc5e6b9a-702d-11e4-941c-9fa256133a41.png)

after:
![screen shot 2014-11-19 at 8 45 59 pm](https://cloud.githubusercontent.com/assets/11367/5119903/cc5aebe6-702d-11e4-9568-c23cd8f76d58.png)

@anamartinez @ashmckenzie @caquino 
