### PR TITLE
use aws sdk v2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,17 @@ PATH
   remote: .
   specs:
     s3_meta_sync (0.5.1)
-      aws-sdk-v1
+      aws-sdk (~> 2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk-v1 (1.59.1)
-      json (~> 1.4)
-      nokogiri (>= 1.4.4)
+    aws-sdk (2.2.16)
+      aws-sdk-resources (= 2.2.16)
+    aws-sdk-core (2.2.16)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.2.16)
+      aws-sdk-core (= 2.2.16)
     bump (0.3.9)
     byebug (2.6.0)
       columnize (~> 0.3)
@@ -17,10 +20,7 @@ GEM
     columnize (0.3.6)
     debugger-linecache (1.2.0)
     diff-lcs (1.1.3)
-    json (1.8.1)
-    mini_portile (0.6.1)
-    nokogiri (1.6.5)
-      mini_portile (~> 0.6.0)
+    jmespath (1.1.3)
     rake (10.0.3)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)
@@ -42,4 +42,4 @@ DEPENDENCIES
   s3_meta_sync!
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ If a downloaded file is does not match it's md5 sum in .s3-meta-sync, the whole 
 ```
     -k, --key KEY                    AWS access key
     -s, --secret SECRET              AWS secret key
-    -r, --region REGION              AWS region if not us-standard
+    -r, --region REGION              AWS region if not us-west-2
     -p, --parallel COUNT             Use COUNT threads for download/upload default: 10
         --ssl-none                   Do not verify ssl certs
     -z, --zip                        Zip when uploading to save bandwidth

--- a/bin/s3-meta-sync
+++ b/bin/s3-meta-sync
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
 $LOAD_PATH << File.expand_path("../../lib", __FILE__)
-require "rubygems" if RUBY_VERSION < "1.9"
 require "s3_meta_sync"
 exit S3MetaSync.run(ARGV)

--- a/s3_meta_sync.gemspec
+++ b/s3_meta_sync.gemspec
@@ -8,6 +8,6 @@ Gem::Specification.new name, S3MetaSync::VERSION do |s|
   s.homepage = "https://github.com/grosser/#{name}"
   s.files = `git ls-files lib/ bin/`.split("\n")
   s.license = "MIT"
-  s.add_runtime_dependency "aws-sdk-v1"
+  s.add_runtime_dependency "aws-sdk", '~> 2.0'
   s.executables = ["s3-meta-sync"]
 end

--- a/spec/s3_meta_sync_spec.rb
+++ b/spec/s3_meta_sync_spec.rb
@@ -421,7 +421,9 @@ describe S3MetaSync do
       end
 
       it "is verbose" do
-        sync("foo #{config[:bucket]}:bar #{params} --verbose").strip.should == <<-TXT.gsub(/^ {10}/, "").strip
+        result = sync("foo #{config[:bucket]}:bar #{params} --verbose").strip
+        result.should == <<-TXT.gsub(/^ {10}/, "").strip
+          Downloading bar/.s3-meta-sync
           Downloading bar/.s3-meta-sync
           Remote has no .s3-meta-sync, uploading everything
           Uploading: 1 Deleting: 0

--- a/spec/s3_meta_sync_spec.rb
+++ b/spec/s3_meta_sync_spec.rb
@@ -8,7 +8,13 @@ describe S3MetaSync do
   end
 
   let(:config) { YAML.load_file(File.expand_path("../credentials.yml", __FILE__)) }
-  let(:s3) { AWS::S3.new(:access_key_id => config[:key], :secret_access_key => config[:secret]).buckets[config[:bucket]] }
+  let(:s3) do
+    ::Aws::S3::Resource.new(
+      access_key_id: config[:key],
+      secret_access_key: config[:secret],
+      region: 'us-west-2'
+    ).bucket(config[:bucket])
+  end
   let(:foo_md5) { "---\n:files:\n  xxx: 0976fb571ada412514fe67273780c510\n" }
   let(:syncer) { S3MetaSync::Syncer.new(config) }
 


### PR DESCRIPTION
@anamartinez @craigday

more of an FYI ... I want to use v2 consistently and s3-meta-sync was depending on v1 ... so removing that :)