### PR TITLE
retry 3 times on generic HTTP errors

### DIFF
--- a/lib/s3_meta_sync.rb
+++ b/lib/s3_meta_sync.rb
@@ -44,7 +44,7 @@ module S3MetaSync
         opts.on("--no-local-changes", "Do not md5 all the local files, they did not change") { options[:no_local_changes] = true }
         opts.on("-V", "--verbose", "Verbose mode"){ options[:verbose] = true }
         opts.on("-h", "--help", "Show this.") { puts opts; exit }
-        opts.on("-v", "--version", "Show Version"){ puts VERSION; exit}
+        opts.on("-v", "--version", "Show Version") { puts VERSION; exit}
       end.parse!(argv)
 
       raise "need source and destination" unless argv.size == 2

--- a/lib/s3_meta_sync/syncer.rb
+++ b/lib/s3_meta_sync/syncer.rb
@@ -246,8 +246,15 @@ module S3MetaSync
       options = (@config[:ssl_none] ? {:ssl_verify_mode => OpenSSL::SSL::VERIFY_NONE} : {})
       open(url, options)
     rescue OpenURI::HTTPError
-      $!.message << " -- while trying to download #{url}"
-      raise
+      retries ||= 0
+      retries += 1
+      if retries >= 3
+        $!.message << " -- while trying to download #{url}"
+        raise
+      else
+        log "HTTP Error downloading #{path}, retrying"
+        retry
+      end
     rescue OpenSSL::SSL::SSLError
       retries ||= 0
       retries += 1


### PR DESCRIPTION
Add in some retry logic. Sometimes AWS will return a 500 for no great reason and it would be nice to be failure tolerant. 

/cc @grosser 