### PR TITLE
Option: http error retries

### DIFF
--- a/lib/s3_meta_sync.rb
+++ b/lib/s3_meta_sync.rb
@@ -42,6 +42,7 @@ module S3MetaSync
         opts.on("--ssl-none", "Do not verify ssl certs") { options[:ssl_none] = true }
         opts.on("-z", "--zip", "Zip when uploading to save bandwidth") { options[:zip] = true }
         opts.on("--no-local-changes", "Do not md5 all the local files, they did not change") { options[:no_local_changes] = true }
+        opts.on("--retries MAX", Integer, "MAX number of times retrying failed http requests default: 2") { |c| options[:max_retries] = c }
         opts.on("-V", "--verbose", "Verbose mode"){ options[:verbose] = true }
         opts.on("-h", "--help", "Show this.") { puts opts; exit }
         opts.on("-v", "--version", "Show Version") { puts VERSION; exit}

--- a/lib/s3_meta_sync/syncer.rb
+++ b/lib/s3_meta_sync/syncer.rb
@@ -263,10 +263,10 @@ module S3MetaSync
       yield
     rescue OpenURI::HTTPError, Errno::ECONNRESET => e
       max_retries = @config[:max_retries] || 2
-      retries ||= Hash.new(0)
-      retries[e.class] += 1
-      if retries[e.class] <= max_retries
-        log "#{e.class} error downloading #{path}, retrying (at #{retries[e.class]})"
+      http_error_retries ||= 0
+      http_error_retries += 1
+      if http_error_retries <= max_retries
+        log "#{e.class} error downloading #{path}, retrying (at #{http_error_retries})"
         retry
       else
         $!.message << " -- while trying to download #{url}"

--- a/lib/s3_meta_sync/syncer.rb
+++ b/lib/s3_meta_sync/syncer.rb
@@ -103,6 +103,7 @@ module S3MetaSync
     end
 
     def copy_content(destination, dir)
+      log "Copying content from #{destination} to #{dir}"
       system "cp -R #{destination}/* #{dir} 2>/dev/null"
     end
 

--- a/lib/s3_meta_sync/syncer.rb
+++ b/lib/s3_meta_sync/syncer.rb
@@ -68,7 +68,7 @@ module S3MetaSync
       log "Downloading: #{download.size} Deleting: #{delete.size}", true
 
       if download.any? || delete.any?
-        mktmpdir do |staging_area|
+        make_temporary_folder do |staging_area|
           FileUtils.mkdir_p(destination)
           copy_content(destination, staging_area)
           download_files(source, staging_area, download, remote_meta[:zip])
@@ -83,7 +83,7 @@ module S3MetaSync
       end
     end
 
-    def mktmpdir
+    def make_temporary_folder
       dir = Dir.mktmpdir("s3ms_")
       log "Tmp folder: #{dir}"
       yield dir

--- a/lib/s3_meta_sync/syncer.rb
+++ b/lib/s3_meta_sync/syncer.rb
@@ -221,9 +221,9 @@ module S3MetaSync
       content = download_content("#{destination}/#{META_FILE}") { |io| io.read }
       parse_yaml_content(content)
     rescue OpenURI::HTTPError
-      retries ||= 1
+      retries ||= 0
+      retries += 1
       if retries <= 1
-        retries += 1
         sleep 1 # maybe the remote meta was just updated ... give aws a second chance ...
         retry
       else
@@ -266,7 +266,7 @@ module S3MetaSync
       http_error_retries ||= 0
       http_error_retries += 1
       if http_error_retries <= max_retries
-        log "#{e.class} error downloading #{path}, retrying (at #{http_error_retries})"
+        log "#{e.class} error downloading #{path}, retrying #{http_error_retries}/#{max_retries}"
         retry
       else
         $!.message << " -- while trying to download #{url}"
@@ -276,7 +276,7 @@ module S3MetaSync
       ssl_error_retries ||= 0
       ssl_error_retries += 1
       if ssl_error_retries == 1
-        log "SSL error downloading #{path}, retrying (at #{ssl_error_retries})"
+        log "SSL error downloading #{path}, retrying #{ssl_error_retries}/#{max_retries}"
         retry
       else
         raise

--- a/spec/s3_meta_sync_spec.rb
+++ b/spec/s3_meta_sync_spec.rb
@@ -238,8 +238,9 @@ describe S3MetaSync do
         path = File.join(Dir.tmpdir, S3MetaSync::Syncer::STAGING_AREA_PREFIX + '*')
         before = Dir[path].size
 
-        allow(no_cred_syncer).to receive(:older_than).and_return(false)
-        allow(no_cred_syncer).to receive(:older_than).with(dir, 24 * 60 * 60).and_return(true)
+        allow(File).to receive(:ctime).and_return(Time.now.utc)
+        ctime = Time.at(Time.now.utc - 25 * 60 * 60)
+        allow(File).to receive(:ctime).with(dir).and_return(ctime)
 
         no_cred_syncer.sync("#{config[:bucket]}:bar", "foo2")
         after = Dir[path].size
@@ -574,11 +575,11 @@ describe S3MetaSync do
         result = sync("foo #{config[:bucket]}:bar #{params} --verbose").strip
         expect(result).to eq <<-TXT.gsub(/^ {10}/, "").strip
           Downloading bar/.s3-meta-sync
-          OpenURI::HTTPError error downloading bar/.s3-meta-sync, retrying 1/2
-          OpenURI::HTTPError error downloading bar/.s3-meta-sync, retrying 2/2
+          OpenURI::HTTPError error downloading https://s3-us-west-2.amazonaws.com/s3-meta-sync-test/bar/.s3-meta-sync, retrying 1/2
+          OpenURI::HTTPError error downloading https://s3-us-west-2.amazonaws.com/s3-meta-sync-test/bar/.s3-meta-sync, retrying 2/2
           Downloading bar/.s3-meta-sync
-          OpenURI::HTTPError error downloading bar/.s3-meta-sync, retrying 1/2
-          OpenURI::HTTPError error downloading bar/.s3-meta-sync, retrying 2/2
+          OpenURI::HTTPError error downloading https://s3-us-west-2.amazonaws.com/s3-meta-sync-test/bar/.s3-meta-sync, retrying 1/2
+          OpenURI::HTTPError error downloading https://s3-us-west-2.amazonaws.com/s3-meta-sync-test/bar/.s3-meta-sync, retrying 2/2
           Remote has no .s3-meta-sync, uploading everything
           Uploading: 1 Deleting: 0
           Uploading xxx

--- a/spec/s3_meta_sync_spec.rb
+++ b/spec/s3_meta_sync_spec.rb
@@ -221,6 +221,17 @@ describe S3MetaSync do
         expect(after).to eq(before)
       end
 
+      it "remove tempdirs left behind by SIGTERM exceptions" do
+        dir = File.dirname(Dir.mktmpdir)
+        Dir.mktmpdir(S3MetaSync::Syncer::TEMP_FOLDER_PREFIX)
+        before = Dir["#{dir}/*"].size
+
+        no_cred_syncer.sync("#{config[:bucket]}:bar", "foo2")
+        after = Dir["#{dir}/*"].size
+
+        expect(after).to eq(before - 1)
+      end
+
       it "downloads nothing when everything is up to date" do
         expect(no_cred_syncer).not_to receive(:download_file)
         expect(no_cred_syncer).not_to receive(:delete_local_files)

--- a/spec/s3_meta_sync_spec.rb
+++ b/spec/s3_meta_sync_spec.rb
@@ -548,11 +548,11 @@ describe S3MetaSync do
         result = sync("foo #{config[:bucket]}:bar #{params} --verbose").strip
         expect(result).to eq <<-TXT.gsub(/^ {10}/, "").strip
           Downloading bar/.s3-meta-sync
-          OpenURI::HTTPError error downloading bar/.s3-meta-sync, retrying (at 1)
-          OpenURI::HTTPError error downloading bar/.s3-meta-sync, retrying (at 2)
+          OpenURI::HTTPError error downloading bar/.s3-meta-sync, retrying 1/2
+          OpenURI::HTTPError error downloading bar/.s3-meta-sync, retrying 2/2
           Downloading bar/.s3-meta-sync
-          OpenURI::HTTPError error downloading bar/.s3-meta-sync, retrying (at 1)
-          OpenURI::HTTPError error downloading bar/.s3-meta-sync, retrying (at 2)
+          OpenURI::HTTPError error downloading bar/.s3-meta-sync, retrying 1/2
+          OpenURI::HTTPError error downloading bar/.s3-meta-sync, retrying 2/2
           Remote has no .s3-meta-sync, uploading everything
           Uploading: 1 Deleting: 0
           Uploading xxx

--- a/spec/s3_meta_sync_spec.rb
+++ b/spec/s3_meta_sync_spec.rb
@@ -222,8 +222,8 @@ describe S3MetaSync do
       end
 
       it "does not remove recent tempdirs left behind by SIGTERM exceptions" do
-        Dir.mktmpdir(S3MetaSync::Syncer::TEMP_FOLDER_PREFIX)
-        path = File.join(Dir.tmpdir, S3MetaSync::Syncer::TEMP_FOLDER_PREFIX + '*')
+        Dir.mktmpdir(S3MetaSync::Syncer::STAGING_AREA_PREFIX)
+        path = File.join(Dir.tmpdir, S3MetaSync::Syncer::STAGING_AREA_PREFIX + '*')
         before = Dir[path].size
 
         no_cred_syncer.sync("#{config[:bucket]}:bar", "foo2")
@@ -233,13 +233,13 @@ describe S3MetaSync do
       end
 
       it "remove older (than a day) tempdirs left behind by SIGTERM exceptions" do
-        Dir.mktmpdir(S3MetaSync::Syncer::TEMP_FOLDER_PREFIX)
-        dir = Dir.mktmpdir(S3MetaSync::Syncer::TEMP_FOLDER_PREFIX)
-        path = File.join(Dir.tmpdir, S3MetaSync::Syncer::TEMP_FOLDER_PREFIX + '*')
+        Dir.mktmpdir(S3MetaSync::Syncer::STAGING_AREA_PREFIX)
+        dir = Dir.mktmpdir(S3MetaSync::Syncer::STAGING_AREA_PREFIX)
+        path = File.join(Dir.tmpdir, S3MetaSync::Syncer::STAGING_AREA_PREFIX + '*')
         before = Dir[path].size
 
         allow(no_cred_syncer).to receive(:older_than).and_return(false)
-        allow(no_cred_syncer).to receive(:older_than).with(dir, 60 * 60 * 24).and_return(true)
+        allow(no_cred_syncer).to receive(:older_than).with(dir, 24 * 60 * 60).and_return(true)
 
         no_cred_syncer.sync("#{config[:bucket]}:bar", "foo2")
         after = Dir[path].size


### PR DESCRIPTION
### Describe
In the case that we're downloading thousands of files at once, if `OpenURI::HTTPError` gets raised after 2 retries, the sync is aborted, and the next run will start over from the beginning. Hopefully increasing the number of retries will prevent sync failures, if not I'll take a look into adding support for partial downloads.

Example:
```
bin/s3-meta-sync --retries 10 -V my_s3_bucket:translations --no-local-changes tmp/translations
Downloading translations/.s3-meta-sync
```

Other changes:
 * prefix temp folder with s3ms
 * ensure temp folder is removed
 * update tests to run on ruby 2.4.1.

Ran tests on ruby 2.4.1 and 2.2.3:

```
(2.4.1) vagrant: /harmony/code/s3_meta_sync (master)$ rspec
.........................................................

Finished in 1 minute 36.08 seconds (files took 0.38627 seconds to load)
57 examples, 0 failures
```

```
(2.2.3) vagrant: /harmony/code/s3_meta_sync (igor/retry_remove_tmp_dir)$ rspec
.........................................................

Finished in 1 minute 37.91 seconds (files took 0.63786 seconds to load)
57 examples, 0 failures
```

### Reviewers
/cc @grosser @zendesk/i18n-dev

### Risks
 * Low. Extra options and small refactoring.