### PR TITLE
Open / read timeout configurable, retry Net::OpenTimeout, Net::ReadTimeout exceptions

### DIFF
--- a/lib/s3_meta_sync.rb
+++ b/lib/s3_meta_sync.rb
@@ -39,6 +39,8 @@ module S3MetaSync
         opts.on("-s", "--secret SECRET", "AWS secret key") { |c| options[:secret] = c }
         opts.on("-r", "--region REGION", "AWS region if not us-standard") { |c| options[:region] = c }
         opts.on("-p", "--parallel COUNT", Integer, "Use COUNT threads for download/upload default: 10") { |c| options[:parallel] = c }
+        opts.on("-o", "--open-timeout TIMEOUT", Integer, "Net::HTTP open timeout in seconds default: 5") { |c| options[:open_timeout] = c }
+        opts.on("-t", "--read-timeout TIMEOUT", Integer, "Net::HTTP read timeout in seconds default: 10") { |c| options[:read_timeout] = c }
         opts.on("--ssl-none", "Do not verify ssl certs") { options[:ssl_none] = true }
         opts.on("-z", "--zip", "Zip when uploading to save bandwidth") { options[:zip] = true }
         opts.on("--no-local-changes", "Do not md5 all the local files, they did not change") { options[:no_local_changes] = true }

--- a/lib/s3_meta_sync/syncer.rb
+++ b/lib/s3_meta_sync/syncer.rb
@@ -274,7 +274,7 @@ module S3MetaSync
 
     def retry_downloads(url:)
       yield
-    rescue OpenURI::HTTPError, Errno::ECONNRESET, Net::OpenTimeout, Net::ReadTimeout => e
+    rescue OpenURI::HTTPError, Errno::ECONNRESET, Errno::ETIMEDOUT, Net::OpenTimeout, Net::ReadTimeout => e
       max_retries = @config[:max_retries] || 2
       http_error_retries ||= 0
       http_error_retries += 1

--- a/spec/s3_meta_sync_spec.rb
+++ b/spec/s3_meta_sync_spec.rb
@@ -466,6 +466,14 @@ describe S3MetaSync do
     it "parses --retries" do
       expect(call(["x:z", "y", "--retries=5"])).to eq(["x:z", "y", defaults.merge(max_retries: 5)])
     end
+
+    it "parses --open-timeout" do
+      expect(call(["x:z", "y", "--open-timeout=3"])).to eq(["x:z", "y", defaults.merge(open_timeout: 3)])
+    end
+
+    it "parses --read-timeout" do
+      expect(call(["x:z", "y", "--read-timeout=7"])).to eq(["x:z", "y", defaults.merge(read_timeout: 7)])
+    end
   end
 
   describe ".download_content" do
@@ -581,6 +589,7 @@ describe S3MetaSync do
           OpenURI::HTTPError error downloading https://s3-us-west-2.amazonaws.com/s3-meta-sync-test/bar/.s3-meta-sync, retrying 1/2
           OpenURI::HTTPError error downloading https://s3-us-west-2.amazonaws.com/s3-meta-sync-test/bar/.s3-meta-sync, retrying 2/2
           Remote has no .s3-meta-sync, uploading everything
+          Storing meta file
           Uploading: 1 Deleting: 0
           Uploading xxx
           Uploading .s3-meta-sync


### PR DESCRIPTION
### Description
Since newer ruby versions set open/read timeout default values (Net::HTTP), makes sense to set reasonable defaults in s3_meta_sync, make it configurable and retry timeout exceptions.

```
(2.4.1) bin/s3-meta-sync --retries 10 -V my_s3_bucket:translations --no-local-changes --read-timeout 5 --open-timeout 3 tmp/translations
```
```
(2.4.1) vagrant: /harmony/code/s3_meta_sync (igor/net_http_timeout)$ rspec
.............................................................

Finished in 1 minute 38.57 seconds (files took 0.23699 seconds to load)
61 examples, 0 failures
```
```
(2.2.3) vagrant: /harmony/code/s3_meta_sync (igor/net_http_timeout)$ rspec
.............................................................

Finished in 1 minute 44.57 seconds (files took 1.06 seconds to load)
61 examples, 0 failures
```

@zendesk/i18n-dev

### Reviewers
/cc @grosser 

### Risks
 * Low. Might take too longer than usual when retrying Net::OpenTimeout, Net::ReadTimeout exceptions.