### PR TITLE
Require net/http

### DIFF
--- a/lib/s3_meta_sync/syncer.rb
+++ b/lib/s3_meta_sync/syncer.rb
@@ -1,3 +1,4 @@
+require "net/http"
 require "open-uri"
 require "yaml"
 require "digest/md5"

--- a/spec/s3_meta_sync_spec.rb
+++ b/spec/s3_meta_sync_spec.rb
@@ -493,6 +493,18 @@ describe S3MetaSync do
       expect(syncer.send(:download_content, "bar/xxx").read).to eq("fff")
     end
 
+    it "retries once on net::http open timeout error" do
+      expect(syncer).to receive(:open).and_raise Net::OpenTimeout.new
+      expect(syncer).to receive(:open).and_return double(read: "fff")
+      expect(syncer.send(:download_content, "bar/xxx").read).to eq("fff")
+    end
+
+    it "retries once on net::http read timeout error" do
+      expect(syncer).to receive(:open).and_raise Net::ReadTimeout.new
+      expect(syncer).to receive(:open).and_return double(read: "fff")
+      expect(syncer.send(:download_content, "bar/xxx").read).to eq("fff")
+    end
+
     it "does not retry multiple times on ssl error" do
       expect(syncer).to receive(:open).exactly(2).and_raise OpenSSL::SSL::SSLError.new
       expect { syncer.send(:download_content, "bar/xxx") }.to raise_error(OpenSSL::SSL::SSLError)


### PR DESCRIPTION
### Description

Somewhere in tests net/http gets loaded, but when syncing files, we'd get
exceptions like this:

uninitialized constant S3MetaSync::Syncer::Net

Added tests for good measure, but they wouldn't catch this bug.

/cc @zendesk/i18n-dev

### Reviewers
/cc @grosser 

### Risks
Low.