### PR TITLE
Update `aws-sdk` to `v3`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,26 @@ PATH
   remote: .
   specs:
     s3_meta_sync (0.13.1)
-      aws-sdk-core (~> 2.0)
+      aws-sdk-s3 (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk-core (2.10.96)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.96.0)
+    aws-sdk-core (3.22.1)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sigv4 (1.0.2)
+    aws-sdk-kms (1.6.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.17.0)
+      aws-sdk-core (~> 3, >= 3.21.2)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.3)
     bump (0.3.9)
     byebug (2.6.0)
       columnize (~> 0.3)
@@ -18,7 +29,7 @@ GEM
     columnize (0.3.6)
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
-    jmespath (1.3.1)
+    jmespath (1.4.0)
     rack (2.0.1)
     rake (10.0.3)
     rspec (3.5.0)

--- a/lib/s3_meta_sync/syncer.rb
+++ b/lib/s3_meta_sync/syncer.rb
@@ -6,7 +6,7 @@ require "fileutils"
 require "tmpdir"
 require "openssl"
 
-require "aws-sdk-core"
+require "aws-sdk-s3"
 require "s3_meta_sync/zip"
 
 module S3MetaSync

--- a/lib/s3_meta_sync/syncer.rb
+++ b/lib/s3_meta_sync/syncer.rb
@@ -195,7 +195,7 @@ module S3MetaSync
     end
 
     def s3
-      @s3 ||= ::Aws::S3::Client.new(
+      @s3 ||= Aws::S3::Client.new(
         access_key_id: @config[:key],
         secret_access_key: @config[:secret],
         region: @config[:region] || 'us-west-2'

--- a/s3_meta_sync.gemspec
+++ b/s3_meta_sync.gemspec
@@ -8,6 +8,6 @@ Gem::Specification.new name, S3MetaSync::VERSION do |s|
   s.homepage = "https://github.com/grosser/#{name}"
   s.files = `git ls-files lib/ bin/`.split("\n")
   s.license = "MIT"
-  s.add_runtime_dependency "aws-sdk-core", '~> 2.0'
+  s.add_runtime_dependency "aws-sdk-s3", '~> 1.0'
   s.executables = ["s3-meta-sync"]
 end


### PR DESCRIPTION
This updates the AWS SDK to use the latest version of the AWS S3 SDK.

This allows the test suite to be run successfully with any valid AWS configuration. 

**Reviewers:**
@grosser @dadah89