### PR TITLE
Support frozen strings

### DIFF
--- a/lib/s3_meta_sync.rb
+++ b/lib/s3_meta_sync.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "optparse"
 require "s3_meta_sync/version"
 require "s3_meta_sync/syncer"

--- a/lib/s3_meta_sync/syncer.rb
+++ b/lib/s3_meta_sync/syncer.rb
@@ -289,7 +289,7 @@ module S3MetaSync
         log "#{e.class} error downloading #{url}, retrying #{http_error_retries}/#{max_retries}"
         retry
       else
-        raise $!, "#{$!.message} -- while trying to download #{url}"
+        raise $!, "#{$!.message} -- while trying to download #{url}", $!.backtrace
       end
     rescue OpenSSL::SSL::SSLError
       ssl_error_retries ||= 0

--- a/lib/s3_meta_sync/syncer.rb
+++ b/lib/s3_meta_sync/syncer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "net/http"
 require "open-uri"
 require "yaml"
@@ -287,8 +289,7 @@ module S3MetaSync
         log "#{e.class} error downloading #{url}, retrying #{http_error_retries}/#{max_retries}"
         retry
       else
-        $!.message << " -- while trying to download #{url}"
-        raise
+        raise $!, "#{$!.message} -- while trying to download #{url}"
       end
     rescue OpenSSL::SSL::SSLError
       ssl_error_retries ||= 0

--- a/lib/s3_meta_sync/version.rb
+++ b/lib/s3_meta_sync/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module S3MetaSync
   VERSION = "0.14.0"
 end

--- a/lib/s3_meta_sync/zip.rb
+++ b/lib/s3_meta_sync/zip.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "zlib"
 require "stringio"
 
@@ -5,7 +7,7 @@ module S3MetaSync
   module Zip
     class << self
       def zip(string)
-        io = StringIO.new("w")
+        io = StringIO.new("w".dup)
         w_gz = Zlib::GzipWriter.new(io)
         w_gz.write(string)
         w_gz.close

--- a/spec/s3_meta_sync_spec.rb
+++ b/spec/s3_meta_sync_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 SingleCov.covered! uncovered: 3 # .run is covered via CLI tests, but does not report coverage
@@ -40,8 +42,8 @@ describe S3MetaSync do
   let(:syncer) { S3MetaSync::Syncer.new(config) }
 
   def cleanup_s3
-    keys = s3.list_objects(bucket: bucket).contents.map { |o| {key: o.key} }
-    s3.delete_objects(bucket: bucket, delete: {objects: keys})
+    keys = s3.list_objects(bucket: bucket).contents.map { |o| { key: o.key } }
+    keys.each_slice(1000) { |sliced_keys| s3.delete_objects(bucket: bucket, delete: { objects: sliced_keys }) }
   end
 
   def upload_simple_structure
@@ -50,12 +52,12 @@ describe S3MetaSync do
   end
 
   def download(file)
-    region = if region && region != S3MetaSync::Syncer::DEFAULT_REGION
+    region_suffix = if region && region != S3MetaSync::Syncer::DEFAULT_REGION
       "-#{region}"
     else
       nil
     end
-    open("https://s3#{region}.amazonaws.com/#{bucket}/#{file}").read
+    open("https://s3#{region_suffix}.amazonaws.com/#{bucket}/#{file}").read
   rescue
     nil
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 
 require "single_cov"


### PR DESCRIPTION
Got `FrozenError: can't modify frozen String` when download failed. Fixed code to work with frozen strings if used with ruby version supports it.

```
(2.5.1) $ rspec
...............................................................

Finished in 1 minute 58.08 seconds (files took 0.66352 seconds to load)
63 examples, 0 failures
```

/cc @grosser 

### Risks
Low.