### PR TITLE
Deal with empty .s3-meta-sync

### DIFF
--- a/lib/s3_meta_sync/syncer.rb
+++ b/lib/s3_meta_sync/syncer.rb
@@ -232,12 +232,15 @@ module S3MetaSync
 
     def read_meta(source)
       file = "#{source}/#{META_FILE}"
-      parse_yaml_content(File.read(file)) unless File.zero?(file)
+      if File.exist?(file)
+        content = File.read(file)
+        parse_yaml_content(content) if content.size > 0
+      end
     end
 
     def download_meta(destination)
       content = download_content("#{destination}/#{META_FILE}") { |io| io.read }
-      raise RemoteWithoutMeta unless content.size > 0
+      raise OpenURI::HTTPError.new('Content is empty', nil) unless content.size > 0
 
       parse_yaml_content(content)
     rescue OpenURI::HTTPError

--- a/lib/s3_meta_sync/syncer.rb
+++ b/lib/s3_meta_sync/syncer.rb
@@ -232,11 +232,13 @@ module S3MetaSync
 
     def read_meta(source)
       file = "#{source}/#{META_FILE}"
-      parse_yaml_content(File.read(file)) if File.exist?(file)
+      parse_yaml_content(File.read(file)) unless File.zero?(file)
     end
 
     def download_meta(destination)
       content = download_content("#{destination}/#{META_FILE}") { |io| io.read }
+      raise RemoteWithoutMeta unless content.size > 0
+
       parse_yaml_content(content)
     rescue OpenURI::HTTPError
       retries ||= 0

--- a/spec/s3_meta_sync_spec.rb
+++ b/spec/s3_meta_sync_spec.rb
@@ -216,6 +216,14 @@ describe S3MetaSync do
         }.to raise_error(S3MetaSync::RemoteWithoutMeta)
       end
 
+      it "fails when .s3-meta-sync is corrupted" do
+        expect {
+          expect(no_cred_syncer).to receive(:download_content).and_return(StringIO.new)
+
+          no_cred_syncer.sync("#{bucket}:bar", "foo")
+        }.to raise_error(S3MetaSync::RemoteWithoutMeta)
+      end
+
       it_downloads_into_an_empty_folder
 
       it "downloads into an absolute folder" do
@@ -352,6 +360,14 @@ describe S3MetaSync do
           no_cred_syncer.sync("#{bucket}:bar", "foo")
 
           expect(File.read("foo/xxx")).to eq("fff\n")
+        end
+
+        it "ignores corrupted .s3-meta-sync" do
+          File.write("foo/.s3-meta-sync", "")
+          no_cred_syncer.sync("#{bucket}:bar", "foo")
+
+          # no .s3-meta-sync forces a re-download
+          expect(File.read("foo/xxx")).to eq("yyy\n")
         end
       end
 

--- a/spec/s3_meta_sync_spec.rb
+++ b/spec/s3_meta_sync_spec.rb
@@ -218,7 +218,9 @@ describe S3MetaSync do
 
       it "fails when .s3-meta-sync is corrupted" do
         expect {
-          expect(no_cred_syncer).to receive(:download_content).and_return(StringIO.new)
+          expect(no_cred_syncer).to receive(:download_content).
+            exactly(2).
+            and_return(StringIO.new)
 
           no_cred_syncer.sync("#{bucket}:bar", "foo")
         }.to raise_error(S3MetaSync::RemoteWithoutMeta)
@@ -360,6 +362,14 @@ describe S3MetaSync do
           no_cred_syncer.sync("#{bucket}:bar", "foo")
 
           expect(File.read("foo/xxx")).to eq("fff\n")
+        end
+
+        it "does not fail if .s3-meta-sync does not exist" do
+          File.delete("foo/.s3-meta-sync")
+          no_cred_syncer.sync("#{bucket}:bar", "foo")
+
+          # no .s3-meta-sync forces a re-download
+          expect(File.read("foo/xxx")).to eq("yyy\n")
         end
 
         it "ignores corrupted .s3-meta-sync" do


### PR DESCRIPTION
For some reason one host got an empty .s3-meta-sync file. If `--no-local-changes` is set, all subsequent downloads fail with a NoMethodError exception.

Yaml.load returns false if content is empty string... For local .s3-meta-sync, we can just ignore the local file and let it recalculate and store a new meta
file.

Also added a check for downloaded meta if it comes empty, let me know if you do not find it useful.

Failing tests:
```
Failures:

  1) S3MetaSync#sync sync remote to local with changes and --no-local-changes set ignores corrupted .s3-meta-sync
     Failure/Error: result.key?(:files) ? result : {files: result} # support new and old format

     NoMethodError:
       undefined method `key?' for false:FalseClass
     # ./lib/s3_meta_sync/syncer.rb:254:in `parse_yaml_content'
     # ./lib/s3_meta_sync/syncer.rb:235:in `read_meta'
     # ./lib/s3_meta_sync/syncer.rb:69:in `download'
     # ./lib/s3_meta_sync/syncer.rb:36:in `sync'
     # ./spec/s3_meta_sync_spec.rb:359:in `block (5 levels) in <top (required)>'
     # ./spec/s3_meta_sync_spec.rb:81:in `chdir'
     # ./spec/s3_meta_sync_spec.rb:81:in `block (3 levels) in <top (required)>'
     # ./spec/s3_meta_sync_spec.rb:80:in `block (2 levels) in <top (required)>'

Finished in 2.65 seconds (files took 0.68525 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/s3_meta_sync_spec.rb:357 # S3MetaSync#sync sync remote to local with changes and --no-local-changes set ignores corrupted .s3-meta-sync

===

Failures:

  1) S3MetaSync#sync sync remote to local fails when remove .s3-meta-sync is corrupted
     Failure/Error:
               expect {
                 expect(no_cred_syncer).to receive(:download_content).and_return(StringIO.new)

                 no_cred_syncer.sync("#{bucket}:bar", "foo")
               }.to raise_error(S3MetaSync::RemoteWithoutMeta)

       expected S3MetaSync::RemoteWithoutMeta, got #<NoMethodError: undefined method `key?' for false:FalseClass> with backtrace:
         # ./lib/s3_meta_sync/syncer.rb:255:in `parse_yaml_content'
         # ./lib/s3_meta_sync/syncer.rb:241:in `download_meta'
         # ./lib/s3_meta_sync/syncer.rb:68:in `download'
         # ./lib/s3_meta_sync/syncer.rb:36:in `sync'
         # ./spec/s3_meta_sync_spec.rb:223:in `block (5 levels) in <top (required)>'
         # ./spec/s3_meta_sync_spec.rb:220:in `block (4 levels) in <top (required)>'
         # ./spec/s3_meta_sync_spec.rb:81:in `chdir'
         # ./spec/s3_meta_sync_spec.rb:81:in `block (3 levels) in <top (required)>'
         # ./spec/s3_meta_sync_spec.rb:80:in `block (2 levels) in <top (required)>'
     # ./spec/s3_meta_sync_spec.rb:220:in `block (4 levels) in <top (required)>'
     # ./spec/s3_meta_sync_spec.rb:81:in `chdir'
     # ./spec/s3_meta_sync_spec.rb:81:in `block (3 levels) in <top (required)>'
     # ./spec/s3_meta_sync_spec.rb:80:in `block (2 levels) in <top (required)>'

Finished in 2.57 seconds (files took 0.67113 seconds to load)
1 example, 1 failure
```

Ruby 2.5.1
```
(2.5.1) $ rspec spec/s3_meta_sync_spec.rb --fail-fast
.................................................................

Finished in 2 minutes 18.8 seconds (files took 0.56968 seconds to load)
65 examples, 0 failures
```

Ruby 2.2.9
```
(2.2.9) $ rspec spec/s3_meta_sync_spec.rb --fail-fast
.................................................................

Finished in 2 minutes 0.4 seconds (files took 0.69134 seconds to load)
65 examples, 0 failures
```

/cc @grosser 

### Risks
Low.