### PR TITLE
Support for private S3 buckets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,9 @@ source "https://rubygems.org"
 gemspec
 
 gem "bump"
+gem "byebug"
+gem 'mime-types'
 gem "rake"
 gem "rspec", "~>3"
-gem "byebug"
 gem "single_cov"
 gem "stub_server"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,9 @@ GEM
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     jmespath (1.4.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0425)
     rack (2.0.1)
     rake (10.0.3)
     rspec (3.5.0)
@@ -55,6 +58,7 @@ PLATFORMS
 DEPENDENCIES
   bump
   byebug
+  mime-types
   rake
   rspec (~> 3)
   s3_meta_sync!
@@ -62,4 +66,4 @@ DEPENDENCIES
   stub_server
 
 BUNDLED WITH
-   1.16.3
+   1.17.3

--- a/spec/s3_meta_sync_spec.rb
+++ b/spec/s3_meta_sync_spec.rb
@@ -567,7 +567,9 @@ describe S3MetaSync do
     end
 
     describe "with retries option" do
-      before { config[:max_retries] = 3 }
+      def config
+        super.merge(max_retries: 3)
+      end
 
       it "retries more than 3 times on a HTTP error" do
         expect(syncer).to receive(:open).exactly(4).and_raise OpenURI::HTTPError.new('http error', nil)


### PR DESCRIPTION
### Description
Adding support for uploading and downloading objects from private S3 buckets (no public URLs).

Giving users the option to use an [AWS Credentials File](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).

Newly added S3 object config/options:
- `content_type` (e.g. "text/plain")
- `content_encoding` (e.g. "UTF-8") - Ensuring that the content encoding is properly set for an object.
- `acl` - Configurable [S3 Access Control List](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html). Previously this was set to `public`, but changes include making it configurable with `public` as default.

Last thing to note is that `DEFAULT_REGION` constant wasn't previously being used. These changes update the code to use the constant but this changes the default region from `'us-west-2'` to `'us-east-1'`.

- [x] All tests pass locally

/cc @grosser 

### Risks
Medium. Old code paths tried to stay untouched, but could introduce unexpected behavior.