### PR TITLE
Add mime-type as a runtime dependency

### DIFF
--- a/s3_meta_sync.gemspec
+++ b/s3_meta_sync.gemspec
@@ -9,5 +9,6 @@ Gem::Specification.new name, S3MetaSync::VERSION do |s|
   s.files = `git ls-files lib/ bin/`.split("\n")
   s.license = "MIT"
   s.add_runtime_dependency "aws-sdk-s3", '~> 1.0'
+  s.add_runtime_dependency "mime-types"
   s.executables = ["s3-meta-sync"]
 end


### PR DESCRIPTION
Syncer does not work without it.

```
LoadError: cannot load such file -- mime/types
/bundle/ruby/2.5.0/gems/s3_meta_sync-0.15.0/lib/s3_meta_sync/syncer.rb:10:in `require'
/bundle/ruby/2.5.0/gems/s3_meta_sync-0.15.0/lib/s3_meta_sync/syncer.rb:10:in `<top (required)>'
/bundle/ruby/2.5.0/gems/s3_meta_sync-0.15.0/lib/s3_meta_sync.rb:5:in `require'
/bundle/ruby/2.5.0/gems/s3_meta_sync-0.15.0/lib/s3_meta_sync.rb:5:in `<top (required)>'
```

cc @grosser @damiann @codealchemy @pschambacher 