### PR TITLE
Syncer#private_content_download: add logging

### DIFF
--- a/lib/s3_meta_sync/syncer.rb
+++ b/lib/s3_meta_sync/syncer.rb
@@ -316,6 +316,7 @@ module S3MetaSync
     end
 
     def private_content_download(source, path)
+      log "Downloading #{path}"
       obj = s3.get_object(bucket: @bucket, key: "#{source}/#{path}")
       obj.body
     end


### PR DESCRIPTION
cc @grosser @damiann @codealchemy

While debugging some issues, realized we weren't logging private content downloads, like we do with public content downloads.

Thought about moving log to `download_file` method, but `private_content_download` is also called from another method.

## Risk
Low. Just adding extra logging.